### PR TITLE
probe: use context instead of explicit timeout args

### DIFF
--- a/pkg/probe/exec/exec.go
+++ b/pkg/probe/exec/exec.go
@@ -18,6 +18,8 @@ limitations under the License.
 package exec
 
 import (
+	"context"
+
 	"k8s.io/klog/v2"
 	"k8s.io/utils/exec"
 
@@ -43,7 +45,7 @@ func New() Prober {
 
 // Prober is an interface defining the Probe object for container readiness/liveness checks.
 type Prober interface {
-	Probe(name string, args ...string) (probe.Result, string, error)
+	Probe(ctx context.Context, name string, args ...string) (probe.Result, string, error)
 }
 
 type execProber struct {
@@ -53,8 +55,8 @@ type execProber struct {
 // Probe executes a command to check the liveness/readiness of container
 // from executing a command. Returns the Result status, command output, and
 // errors if any.
-func (pr execProber) Probe(name string, args ...string) (probe.Result, string, error) {
-	cmd := pr.runner.Command(name, args...)
+func (pr execProber) Probe(ctx context.Context, name string, args ...string) (probe.Result, string, error) {
+	cmd := pr.runner.CommandContext(ctx, name, args...)
 	data, err := cmd.CombinedOutput()
 
 	klog.V(4).Infof("Exec probe response: %q", string(data))

--- a/pkg/probe/exec/exec_test.go
+++ b/pkg/probe/exec/exec_test.go
@@ -153,11 +153,11 @@ func TestExec(t *testing.T) {
 
 		mockExecutor := &fakeExecutor{}
 		// there's no clean way to assert on the created command other than a mock
-		mockExecutor.On("Command", "foo", []string{"arg1", "arg2"}).Return(&fake)
+		mockExecutor.On("CommandContext", mock.Anything, "foo", []string{"arg1", "arg2"}).Return(&fake)
 
 		prober := execProber{runner: mockExecutor}
 
-		status, output, err := prober.Probe("foo", "arg1", "arg2")
+		status, output, err := prober.Probe(context.Background(), "foo", "arg1", "arg2")
 		if status != test.expectedStatus {
 			t.Errorf("[%d] expected %v, got %v", i, test.expectedStatus, status)
 		}

--- a/pkg/probe/tcp/tcp_test.go
+++ b/pkg/probe/tcp/tcp_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package tcp
 
 import (
+	"context"
+	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -57,12 +59,16 @@ func TestTcpHealthChecker(t *testing.T) {
 
 	prober := New()
 	for i, tt := range tests {
-		status, _, err := prober.Probe(tt.host, tt.port, 1*time.Second)
-		if status != tt.expectedStatus {
-			t.Errorf("#%d: expected status=%v, get=%v", i, tt.expectedStatus, status)
-		}
-		if err != tt.expectedError {
-			t.Errorf("#%d: expected error=%v, get=%v", i, tt.expectedError, err)
-		}
+		t.Run(fmt.Sprintf("[%d] %s:%d", i, tt.host, tt.port), func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+			defer cancel()
+			status, _, err := prober.Probe(ctx, tt.host, tt.port)
+			if status != tt.expectedStatus {
+				t.Errorf("#%d: expected status=%v, get=%v", i, tt.expectedStatus, status)
+			}
+			if err != tt.expectedError {
+				t.Errorf("#%d: expected error=%v, get=%v", i, tt.expectedError, err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
The underlying TCP/HTTP code in Go stdlib uses context to apply the
timeouts anyway, so this doesn't affect things much. The biggest
motivation is that `exec.CommandContext` is far and away the most
straightforward way to limit how long a process can execute for and
have it auto-killed, so while we could take a timeout arg there and
make a context with it, it seems reasonable to make everything
consistent and give the caller full control over probe lifetime.