### PR TITLE
worker: standardized interface

### DIFF
--- a/pkg/probe/probe.go
+++ b/pkg/probe/probe.go
@@ -32,5 +32,24 @@ const (
 	Unknown Result = "unknown"
 )
 
-// Probe is a check to determine service status.
-type Probe func(ctx context.Context) (Result, string, error)
+// Prober performs a check to determine a service status.
+type Prober interface {
+	// Probe executes a single status check.
+	//
+	// result is the current service status
+	// output is optional info from the probe (such as a process stdout or HTTP response)
+	// err indicates an issue with the probe itself and that the result should be ignored
+	Probe(ctx context.Context) (result Result, output string, err error)
+}
+
+// ProberFunc is a functional version of Prober.
+type ProberFunc func(ctx context.Context) (Result, string, error)
+
+// Probe executes a single status check.
+//
+// result is the current service status
+// output is optional info from the probe (such as a process stdout or HTTP response)
+// err indicates an issue with the probe itself and that the result should be ignored
+func (f ProberFunc) Probe(ctx context.Context) (Result, string, error) {
+	return f(ctx)
+}


### PR DESCRIPTION
This will be paired with a prober manager that can keep a single
instance of each prober to be invoked for each probe by wrapping
in a func to meet the `Probe` signature. This is a good middle
ground between having `Worker` know TOO much and forcing a 1:1
lifecycle of prober:worker.

It's simpler than K8s model because over there the worker is
actually passed the prober manager and then calls back into it with
the relevant container + options and the prober manager does a LOT.
(This approach doesn't prevent from doing more, the functions can
always be wrapped as necessary.)