### PR TITLE
meta: re-organize package + cleanup docs

### DIFF
--- a/pkg/probe/worker_test.go
+++ b/pkg/probe/worker_test.go
@@ -9,22 +9,24 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/tilt-dev/probe/pkg/prober"
 )
 
 type staticProbe struct {
 	mu     sync.Mutex
-	result Result
+	result prober.Result
 	output string
 	err    error
 }
 
-func (s *staticProbe) Probe(_ context.Context) (Result, string, error) {
+func (s *staticProbe) Probe(_ context.Context) (prober.Result, string, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.result, s.output, s.err
 }
 
-func (s *staticProbe) update(result Result, output string, err error) {
+func (s *staticProbe) update(result prober.Result, output string, err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.result = result
@@ -32,7 +34,7 @@ func (s *staticProbe) update(result Result, output string, err error) {
 	s.err = err
 }
 
-func newStaticProbe(result Result, output string, err error) *staticProbe {
+func newStaticProbe(result prober.Result, output string, err error) *staticProbe {
 	return &staticProbe{result: result, output: output, err: err}
 }
 
@@ -53,7 +55,7 @@ func resultsChan() (chan probeResult, WorkerOption) {
 }
 
 func TestNewProberDefaults(t *testing.T) {
-	testProbe := newStaticProbe(Success, "", nil)
+	testProbe := newStaticProbe(prober.Success, "", nil)
 	w := NewWorker(testProbe)
 	assert.NotNil(t, w)
 	assert.NotNil(t, w.prober)
@@ -63,11 +65,11 @@ func TestNewProberDefaults(t *testing.T) {
 	assert.Equal(t, DefaultProbeFailureThreshold, w.failureThreshold)
 	assert.Equal(t, DefaultInitialDelay, w.initialDelay)
 	assert.Nil(t, w.statusFunc)
-	assert.Equal(t, w.Status(), Unknown)
+	assert.Equal(t, w.Status(), prober.Unknown)
 }
 
 func TestNewProberOptions(t *testing.T) {
-	testProbe := newStaticProbe(Success, "test output", nil)
+	testProbe := newStaticProbe(prober.Success, "test output", nil)
 	t.Run("WorkerPeriod", func(t *testing.T) {
 		w := NewWorker(testProbe, WorkerPeriod(5*time.Minute))
 		assert.Equal(t, 5*time.Minute, w.period)
@@ -95,13 +97,13 @@ func TestNewProberOptions(t *testing.T) {
 
 	t.Run("WorkerOnStatusChange", func(t *testing.T) {
 		called := false
-		statusFunc := func(status Result, output string) {
+		statusFunc := func(status prober.Result, output string) {
 			called = true
 		}
 
 		w := NewWorker(testProbe, WorkerOnStatusChange(statusFunc))
 		assert.NotNil(t, w.statusFunc)
-		w.statusFunc(Success, "test output")
+		w.statusFunc(prober.Success, "test output")
 		assert.True(t, called)
 	})
 }
@@ -109,13 +111,13 @@ func TestNewProberOptions(t *testing.T) {
 func TestInitialDelay(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
-	statusFunc := func(status Result, output string) {
+	statusFunc := func(status prober.Result, output string) {
 		wg.Done()
 	}
 
 	c, withMockClock := mockClock()
 
-	w := NewWorker(newStaticProbe(Success, "", nil),
+	w := NewWorker(newStaticProbe(prober.Success, "", nil),
 		WorkerOnStatusChange(statusFunc),
 		WorkerInitialDelay(1*time.Minute),
 		withMockClock)
@@ -124,23 +126,23 @@ func TestInitialDelay(t *testing.T) {
 	defer w.Stop()
 
 	c.BlockUntil(1)
-	assert.Equal(t, Failure, w.Status())
+	assert.Equal(t, prober.Failure, w.Status())
 
 	c.Advance(30 * time.Second)
-	assert.Equal(t, Failure, w.Status())
+	assert.Equal(t, prober.Failure, w.Status())
 
 	c.Advance(30 * time.Second)
 	wg.Wait()
-	assert.Equal(t, Success, w.Status())
+	assert.Equal(t, prober.Success, w.Status())
 }
 
-func sleepProbe(duration time.Duration) ProberFunc {
-	return func(ctx context.Context) (Result, string, error) {
+func sleepProbe(duration time.Duration) prober.ProberFunc {
+	return func(ctx context.Context) (prober.Result, string, error) {
 		select {
 		case <-ctx.Done():
-			return Unknown, "context done", nil
+			return prober.Unknown, "context done", nil
 		case <-time.After(duration):
-			return Success, "sleep finished", nil
+			return prober.Success, "sleep finished", nil
 		}
 	}
 }
@@ -155,9 +157,9 @@ func TestTimeout(t *testing.T) {
 
 	// ensure that a result was received but that it did NOT come from our probe
 	result := <-results
-	assert.Equal(t, Failure, result.result)
+	assert.Equal(t, prober.Failure, result.result)
 	assert.Equal(t, "", result.output)
-	assert.Equal(t, Failure, w.Status())
+	assert.Equal(t, prober.Failure, w.Status())
 }
 
 func TestStop(t *testing.T) {
@@ -170,12 +172,12 @@ func TestStop(t *testing.T) {
 	w.Stop()
 
 	assert.Nil(t, w.stopFunc)
-	assert.Equal(t, Unknown, w.Status())
+	assert.Equal(t, prober.Unknown, w.Status())
 }
 
 func TestThresholds(t *testing.T) {
 	type tc struct {
-		expectedStatus Result
+		expectedStatus prober.Result
 		opts           []WorkerOption
 	}
 
@@ -183,11 +185,11 @@ func TestThresholds(t *testing.T) {
 
 	tcs := []tc{
 		{
-			Success,
+			prober.Success,
 			[]WorkerOption{WorkerFailureThreshold(1), WorkerSuccessThreshold(threshold)},
 		},
 		{
-			Failure,
+			prober.Failure,
 			[]WorkerOption{WorkerFailureThreshold(threshold), WorkerSuccessThreshold(1)},
 		},
 	}
@@ -196,11 +198,11 @@ func TestThresholds(t *testing.T) {
 		t.Run(string(tc.expectedStatus), func(t *testing.T) {
 			results, withResultsChan := resultsChan()
 			c, withMockClock := mockClock()
-			var initialStatus Result
-			if tc.expectedStatus == Success {
-				initialStatus = Failure
-			} else if tc.expectedStatus == Failure {
-				initialStatus = Success
+			var initialStatus prober.Result
+			if tc.expectedStatus == prober.Success {
+				initialStatus = prober.Failure
+			} else if tc.expectedStatus == prober.Failure {
+				initialStatus = prober.Success
 			} else {
 				require.Fail(t, "Unsupported status: %s", tc.expectedStatus)
 			}

--- a/pkg/prober/prober.go
+++ b/pkg/prober/prober.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2015 The Kubernetes Authors.
+Modified 2021 Windmill Engineering.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,21 +15,23 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package probe
+package prober
 
 import "context"
 
-// Result is a string used to handle the results for probing container readiness/liveness
+// Result is a string used to indicate service status.
 type Result string
 
 const (
-	// Success Result
+	// Success indicates that the service is healthy.
 	Success Result = "success"
-	// Warning Result. Logically success, but with additional debugging information attached.
+	// Warning indicates that the service is healthy but additional diagnostic information might be attached.
 	Warning Result = "warning"
-	// Failure Result
+	// Failure indicates that the service is not healthy.
 	Failure Result = "failure"
-	// Unknown Result
+	// Unknown indicates that the prober was unable to determine the service status due to an internal issue.
+	//
+	// An Unknown result should also include an error in the Prober return values.
 	Unknown Result = "unknown"
 )
 

--- a/pkg/prober/tcp.go
+++ b/pkg/prober/tcp.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2015 The Kubernetes Authors.
+Modified 2021 Windmill Engineering.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package tcp
+package prober
 
 import (
 	"context"
@@ -22,40 +23,44 @@ import (
 	"strconv"
 
 	"k8s.io/klog/v2"
-
-	"github.com/tilt-dev/probe/pkg/probe"
 )
 
-// New creates Prober.
-func New() Prober {
+// NewTCPSocketProber creates a TCPSocketProber that checks connectivity to a given address
+// to determine service status.
+func NewTCPSocketProber() TCPSocketProber {
 	return tcpProber{}
 }
 
-// Prober is an interface that defines the Probe function for doing TCP readiness/liveness checks.
-type Prober interface {
-	Probe(ctx context.Context, host string, port int) (probe.Result, string, error)
+// TCPSocketProber establishes a TCP socket to determine service status.
+type TCPSocketProber interface {
+	// Probe establishes a TCP socket to determine service status.
+	//
+	// Any error establishing the TCP connection will return Failure.
+	// In the event of inability to establish a TCP connection, the output will include error information.
+	// Successful TCP connections will result in no output returned.
+	Probe(ctx context.Context, host string, port int) (Result, string, error)
 }
 
 type tcpProber struct{}
 
-// Probe returns a ProbeRunner capable of running an TCP check.
-func (pr tcpProber) Probe(ctx context.Context, host string, port int) (probe.Result, string, error) {
+// Probe establishes a TCP socket to determine service status.
+func (pr tcpProber) Probe(ctx context.Context, host string, port int) (Result, string, error) {
 	return doTCPProbe(ctx, net.JoinHostPort(host, strconv.Itoa(port)))
 }
 
 // doTCPProbe checks that a TCP socket to the address can be opened.
 // If the socket can be opened, it returns Success
 // If the socket fails to open, it returns Failure.
-func doTCPProbe(ctx context.Context, addr string) (probe.Result, string, error) {
+func doTCPProbe(ctx context.Context, addr string) (Result, string, error) {
 	var d net.Dialer
 	conn, err := d.DialContext(ctx, "tcp", addr)
 	if err != nil {
 		// Convert errors to failures to handle timeouts.
-		return probe.Failure, err.Error(), nil
+		return Failure, err.Error(), nil
 	}
 	err = conn.Close()
 	if err != nil {
 		klog.Errorf("Unexpected error closing TCP probe socket: %v (%#v)", err, err)
 	}
-	return probe.Success, "", nil
+	return Success, "", nil
 }

--- a/pkg/prober/tcp_test.go
+++ b/pkg/prober/tcp_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2015 The Kubernetes Authors.
+Modified 2021 Windmill Engineering.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package tcp
+package prober
 
 import (
 	"context"
@@ -25,8 +26,6 @@ import (
 	"strconv"
 	"testing"
 	"time"
-
-	"github.com/tilt-dev/probe/pkg/probe"
 )
 
 func TestTcpHealthChecker(t *testing.T) {
@@ -48,16 +47,16 @@ func TestTcpHealthChecker(t *testing.T) {
 		host string
 		port int
 
-		expectedStatus probe.Result
+		expectedStatus Result
 		expectedError  error
 	}{
 		// A connection is made and probing would succeed
-		{tHost, tPort, probe.Success, nil},
+		{tHost, tPort, Success, nil},
 		// No connection can be made and probing would fail
-		{tHost, -1, probe.Failure, nil},
+		{tHost, -1, Failure, nil},
 	}
 
-	prober := New()
+	prober := NewTCPSocketProber()
 	for i, tt := range tests {
 		t.Run(fmt.Sprintf("[%d] %s:%d", i, tt.host, tt.port), func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)


### PR DESCRIPTION
This is really in service of the introduction of a prober manager
to avoid having an unnecessary diamond dependency.